### PR TITLE
Add profiles for injected services selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
@@ -32,13 +37,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
 		<!-- Add UNDERTOW instead -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-undertow</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -49,6 +52,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,19 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<!-- Remove TOMCAT default dependency -->
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- Add UNDERTOW instead -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/theodo/Albeniz/Exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/theodo/Albeniz/Exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.theodo.Albeniz.Exceptions;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UnknownMusicId.class)
+    public ResponseEntity<String> handleBadRequestException(UnknownMusicId unknownMusicIdException) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(unknownMusicIdException.getMessage());
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/Exceptions/UnknownMusicId.java
+++ b/src/main/java/com/theodo/Albeniz/Exceptions/UnknownMusicId.java
@@ -1,0 +1,7 @@
+package com.theodo.Albeniz.Exceptions;
+
+public class UnknownMusicId extends RuntimeException {
+    public UnknownMusicId (String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/Service/InDatabaseLibraryService.java
+++ b/src/main/java/com/theodo/Albeniz/Service/InDatabaseLibraryService.java
@@ -1,0 +1,21 @@
+package com.theodo.Albeniz.Service;
+
+import com.theodo.Albeniz.dto.Tune;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@Profile("database")
+public class InDatabaseLibraryService implements LibraryService {
+    @Override
+    public List<Tune> getMusic(String query) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Tune getOne(int musicId) {
+        return null;
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/Service/InMemoryLibraryServiceMock.java
+++ b/src/main/java/com/theodo/Albeniz/Service/InMemoryLibraryServiceMock.java
@@ -1,0 +1,45 @@
+package com.theodo.Albeniz.Service;
+
+import com.theodo.Albeniz.Exceptions.UnknownMusicId;
+import com.theodo.Albeniz.dto.Tune;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@Profile("memory")
+public class InMemoryLibraryServiceMock implements LibraryService {
+
+    private final static Map<Integer, Tune> LIBRARY = new HashMap<>();
+
+    static {
+        // ADD static values (temporary)
+        LIBRARY.put(1, new Tune(1, "Thriller", "MJ"));
+        LIBRARY.put(2, new Tune(2, "Bohemian Rhapsody", "Queen"));
+        LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
+    }
+
+    @Override
+    public Tune getOne(int musicId) {
+        if (LIBRARY.containsKey(musicId)) {
+            // Mapping
+            return LIBRARY.get(musicId);
+        }
+        throw new UnknownMusicId(String.format("Unknown music ID: %s", musicId));
+    }
+    @Override
+    public List<Tune> getMusic(String musicTitleQuery) {
+        return musicTitleQuery!=null ? getBySearch(musicTitleQuery) : getAll();
+    }
+    public List<Tune> getAll() {return new ArrayList<Tune>(LIBRARY.values());}
+    public List<Tune> getBySearch(String query) {
+        Stream<Tune> searchResultStream = LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
+        return searchResultStream.collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/Service/LibraryService.java
+++ b/src/main/java/com/theodo/Albeniz/Service/LibraryService.java
@@ -1,0 +1,36 @@
+package com.theodo.Albeniz.Service;
+
+import com.theodo.Albeniz.Exceptions.UnknownMusicId;
+import com.theodo.Albeniz.dto.Tune;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Service
+public class LibraryService {
+
+    private final static Map<Integer, Tune> LIBRARY = new HashMap<>();
+
+    static {
+        // ADD static values (temporary)
+        LIBRARY.put(1, new Tune(1, "Thriller", "MJ"));
+        LIBRARY.put(2, new Tune(2, "Bohemian Rapsody", "Queen"));
+        LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
+    }
+    public Stream<Tune> getAll() {
+        return LIBRARY.values().stream();
+    }
+    public Stream<Tune> getBySearch(String query) {
+        return LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
+    }
+    public Tune getOne(int musicId) {
+        if (LIBRARY.containsKey(musicId)) {
+            // Mapping
+            return LIBRARY.get(musicId);
+        }
+        throw new UnknownMusicId(String.format("Unknown music ID: %s", musicId));
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/Service/LibraryService.java
+++ b/src/main/java/com/theodo/Albeniz/Service/LibraryService.java
@@ -2,11 +2,13 @@ package com.theodo.Albeniz.Service;
 
 import com.theodo.Albeniz.Exceptions.UnknownMusicId;
 import com.theodo.Albeniz.dto.Tune;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -17,20 +19,23 @@ public class LibraryService {
     static {
         // ADD static values (temporary)
         LIBRARY.put(1, new Tune(1, "Thriller", "MJ"));
-        LIBRARY.put(2, new Tune(2, "Bohemian Rapsody", "Queen"));
+        LIBRARY.put(2, new Tune(2, "Bohemian Rhapsody", "Queen"));
         LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
     }
-    public Stream<Tune> getAll() {
-        return LIBRARY.values().stream();
-    }
-    public Stream<Tune> getBySearch(String query) {
-        return LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
-    }
+
     public Tune getOne(int musicId) {
         if (LIBRARY.containsKey(musicId)) {
             // Mapping
             return LIBRARY.get(musicId);
         }
         throw new UnknownMusicId(String.format("Unknown music ID: %s", musicId));
+    }
+    public List<Tune> getMusic(String musicTitleQuery) {
+        return musicTitleQuery!=null ? getBySearch(musicTitleQuery) : getAll();
+    }
+    public List<Tune> getAll() {return new ArrayList<Tune>(LIBRARY.values());}
+    public List<Tune> getBySearch(String query) {
+        Stream<Tune> searchResultStream = LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
+        return searchResultStream.collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/theodo/Albeniz/Service/LibraryService.java
+++ b/src/main/java/com/theodo/Albeniz/Service/LibraryService.java
@@ -1,41 +1,10 @@
 package com.theodo.Albeniz.Service;
 
-import com.theodo.Albeniz.Exceptions.UnknownMusicId;
 import com.theodo.Albeniz.dto.Tune;
-import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-@Service
-public class LibraryService {
-
-    private final static Map<Integer, Tune> LIBRARY = new HashMap<>();
-
-    static {
-        // ADD static values (temporary)
-        LIBRARY.put(1, new Tune(1, "Thriller", "MJ"));
-        LIBRARY.put(2, new Tune(2, "Bohemian Rhapsody", "Queen"));
-        LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
-    }
-
-    public Tune getOne(int musicId) {
-        if (LIBRARY.containsKey(musicId)) {
-            // Mapping
-            return LIBRARY.get(musicId);
-        }
-        throw new UnknownMusicId(String.format("Unknown music ID: %s", musicId));
-    }
-    public List<Tune> getMusic(String musicTitleQuery) {
-        return musicTitleQuery!=null ? getBySearch(musicTitleQuery) : getAll();
-    }
-    public List<Tune> getAll() {return new ArrayList<Tune>(LIBRARY.values());}
-    public List<Tune> getBySearch(String query) {
-        Stream<Tune> searchResultStream = LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
-        return searchResultStream.collect(Collectors.toList());
-    }
+public interface LibraryService {
+    Tune getOne(int musicId);
+    List<Tune> getMusic(String musicTitleQuery);
 }

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -1,17 +1,40 @@
 package com.theodo.Albeniz.controller;
 
+import com.theodo.Albeniz.Exceptions.UnknownMusicId;
 import com.theodo.Albeniz.dto.Tune;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping(value = "/library")
 public class LibraryController {
-    @GetMapping(value = "/music")
-    public Collection<Tune> getMusic() {
-        return Arrays.asList(new Tune("Thriller", "MJ"), new Tune("Bohemian Rapsody", "Queen"), new Tune("Allumer le feu", "Johnny"));
+
+    private final static Map<Integer, Tune> LIBRARY = new HashMap<>();
+
+    static {
+        // ADD static values (temporary)
+        LIBRARY.put(1, new Tune(1, "Thriller", "MJ"));
+        LIBRARY.put(2, new Tune(2, "Bohemian Rapsody", "Queen"));
+        LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
     }
 
+    @GetMapping(value = "/music")
+    public Collection<Tune> getMusic() {
+        return LIBRARY.values();
+    }
+
+    @GetMapping("music/{musicId}")
+    public Tune getMusic(@PathVariable("musicId") int musicId) throws Exception {
+        if (LIBRARY.containsKey(musicId)) {
+            // Mapping
+            return LIBRARY.get(musicId);
+        }
+
+        throw new UnknownMusicId(String.format("Unknown music ID: %s", musicId));
+    }
 }
+

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -1,13 +1,12 @@
+
 package com.theodo.Albeniz.controller;
 
-import com.theodo.Albeniz.Exceptions.UnknownMusicId;
 import com.theodo.Albeniz.Service.LibraryService;
 import com.theodo.Albeniz.dto.Tune;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 @RestController
 @RequestMapping(value = "/library")
@@ -17,12 +16,8 @@ public class LibraryController {
     private final LibraryService libraryService;
 
     @GetMapping(value = "/music")
-    public Stream<Tune> getMusic(@RequestParam(required = false) String query) {
-        if (query != null){
-            return this.libraryService.getBySearch(query);
-        } else {
-            return this.libraryService.getAll();
-        }
+    public List<Tune> getMusic(@RequestParam(required = false) String query) {
+        return libraryService.getMusic(query);
     }
 
     @GetMapping("music/{musicId}")
@@ -30,4 +25,3 @@ public class LibraryController {
         return this.libraryService.getOne(musicId);
     }
 }
-

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -1,5 +1,6 @@
 package com.theodo.Albeniz.controller;
 
+import com.theodo.Albeniz.dto.Tune;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
@@ -9,7 +10,8 @@ import java.util.Collection;
 @RequestMapping(value = "/library")
 public class LibraryController {
     @GetMapping(value = "/music")
-    public Collection<String> getMusic() {
-        return Arrays.asList("Thriller", "Bohemian Rapsody", "Allumer le feu");
+    public Collection<Tune> getMusic() {
+        return Arrays.asList(new Tune("Thriller", "MJ"), new Tune("Bohemian Rapsody", "Queen"), new Tune("Allumer le feu", "Johnny"));
     }
+
 }

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @RestController
 @RequestMapping(value = "/library")
@@ -22,9 +23,13 @@ public class LibraryController {
         LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
     }
 
-    @GetMapping(value = "/music")
-    public Collection<Tune> getMusic() {
-        return LIBRARY.values();
+    @RequestMapping(value = "/music", method = RequestMethod.GET, params = {"query"})
+    public Stream<Tune> getMusic(@RequestParam String query) {
+        return LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
+    }
+    @RequestMapping(value = "/music", method = RequestMethod.GET)
+    public Stream<Tune> getMusic() {
+        return LIBRARY.values().stream();
     }
 
     @GetMapping("music/{musicId}")

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -1,46 +1,33 @@
 package com.theodo.Albeniz.controller;
 
 import com.theodo.Albeniz.Exceptions.UnknownMusicId;
+import com.theodo.Albeniz.Service.LibraryService;
 import com.theodo.Albeniz.dto.Tune;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Stream;
 
 @RestController
 @RequestMapping(value = "/library")
+@RequiredArgsConstructor
 public class LibraryController {
 
-    private final static Map<Integer, Tune> LIBRARY = new HashMap<>();
-
-    static {
-        // ADD static values (temporary)
-        LIBRARY.put(1, new Tune(1, "Thriller", "MJ"));
-        LIBRARY.put(2, new Tune(2, "Bohemian Rapsody", "Queen"));
-        LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
-    }
+    private final LibraryService libraryService;
 
     @GetMapping(value = "/music")
     public Stream<Tune> getMusic(@RequestParam(required = false) String query) {
         if (query != null){
-            return LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
+            return this.libraryService.getBySearch(query);
         } else {
-            return LIBRARY.values().stream();
+            return this.libraryService.getAll();
         }
-
     }
 
     @GetMapping("music/{musicId}")
-    public Tune getMusic(@PathVariable("musicId") int musicId) throws Exception {
-        if (LIBRARY.containsKey(musicId)) {
-            // Mapping
-            return LIBRARY.get(musicId);
-        }
-
-        throw new UnknownMusicId(String.format("Unknown music ID: %s", musicId));
+    public Tune getMusic(@PathVariable("musicId") int musicId) {
+        return this.libraryService.getOne(musicId);
     }
 }
 

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -23,13 +23,14 @@ public class LibraryController {
         LIBRARY.put(3, new Tune(3, "Allumer le feu", "Johnny"));
     }
 
-    @RequestMapping(value = "/music", method = RequestMethod.GET, params = {"query"})
-    public Stream<Tune> getMusic(@RequestParam String query) {
-        return LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
-    }
-    @RequestMapping(value = "/music", method = RequestMethod.GET)
-    public Stream<Tune> getMusic() {
-        return LIBRARY.values().stream();
+    @GetMapping(value = "/music")
+    public Stream<Tune> getMusic(@RequestParam(required = false) String query) {
+        if (query != null){
+            return LIBRARY.values().stream().filter(element -> element.getTitle().contains(query));
+        } else {
+            return LIBRARY.values().stream();
+        }
+
     }
 
     @GetMapping("music/{musicId}")

--- a/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
+++ b/src/main/java/com/theodo/Albeniz/controller/LibraryController.java
@@ -1,0 +1,15 @@
+package com.theodo.Albeniz.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RestController
+@RequestMapping(value = "/library")
+public class LibraryController {
+    @GetMapping(value = "/music")
+    public Collection<String> getMusic() {
+        return Arrays.asList("Thriller", "Bohemian Rapsody", "Allumer le feu");
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/dto/Tune.java
+++ b/src/main/java/com/theodo/Albeniz/dto/Tune.java
@@ -2,12 +2,14 @@ package com.theodo.Albeniz.dto;
 
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Tune {
     private int id;
     private String title;

--- a/src/main/java/com/theodo/Albeniz/dto/Tune.java
+++ b/src/main/java/com/theodo/Albeniz/dto/Tune.java
@@ -1,0 +1,22 @@
+package com.theodo.Albeniz.dto;
+
+public class Tune {
+    private String title;
+    private String author;
+    public Tune(String title, String author) {
+        this.title = title;
+        this.author = author;
+    }
+    public String getTitle() {
+        return title;
+    }
+    public void setTitle(String title){
+        this.title = title;
+    }
+    public String getAuthor() {
+        return author;
+    }
+    public void setAuthor(String author){
+        this.author = author;
+    }
+}

--- a/src/main/java/com/theodo/Albeniz/dto/Tune.java
+++ b/src/main/java/com/theodo/Albeniz/dto/Tune.java
@@ -1,22 +1,14 @@
 package com.theodo.Albeniz.dto;
 
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
 public class Tune {
     private String title;
     private String author;
-    public Tune(String title, String author) {
-        this.title = title;
-        this.author = author;
-    }
-    public String getTitle() {
-        return title;
-    }
-    public void setTitle(String title){
-        this.title = title;
-    }
-    public String getAuthor() {
-        return author;
-    }
-    public void setAuthor(String author){
-        this.author = author;
-    }
 }

--- a/src/main/java/com/theodo/Albeniz/dto/Tune.java
+++ b/src/main/java/com/theodo/Albeniz/dto/Tune.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class Tune {
+    private int id;
     private String title;
     private String author;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Albeniz

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+info:
+  version: 1.0.0
+
+## Properties for Spring itself
+spring:
+  application:
+    name: albeniz-api
+
+# Change Actuator base URI
+management:
+  endpoints:
+    web:
+      base-path: /tooling
+      exposure:
+        include: "health,info"
+
+## Change Server base context
+server:
+  error.whitelabel.enabled: false
+  servlet:
+    context-path: /albeniz

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerIT.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerIT.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles(profiles="database")
 public class LibraryControllerIT {
 
     @Autowired

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerIT.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerIT.java
@@ -3,7 +3,7 @@ package com.theodo.Albeniz.controller;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -11,9 +11,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = LibraryController.class)
+@SpringBootTest
 @AutoConfigureMockMvc
-public class LibraryControllerTest {
+public class LibraryControllerIT {
 
     @Autowired
     private MockMvc mockMvc;
@@ -31,7 +31,7 @@ public class LibraryControllerTest {
         }
 
     @Test
-    public void testGetSpecificMusicById() throws Exception{
+    public void testGetSpecificMusicById() throws Exception {
         mockMvc.perform(get("/library/music/1").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json("{'id': 1, 'title': 'Thriller', 'author': 'MJ'}"));
@@ -46,7 +46,7 @@ public class LibraryControllerTest {
     @Test
     public void testServerError() throws Exception{
         mockMvc.perform(get("/library/music/0"))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().isInternalServerError());
     }
 
     @Test

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerIT.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerIT.java
@@ -25,10 +25,10 @@ public class LibraryControllerIT {
                 .andExpect(content().json(
                         "[" +
                                 "{'id': 1, 'title': 'Thriller', 'author': 'MJ'}," +
-                                "{'id': 2, 'title': 'Bohemian Rapsody', 'author': 'Queen'}," +
+                                "{'id': 2, 'title': 'Bohemian Rhapsody', 'author': 'Queen'}," +
                                 "{'id': 3, 'title': 'Allumer le feu', 'author': 'Johnny'}" +
                                 "]"));
-        }
+    }
 
     @Test
     public void testGetSpecificMusicById() throws Exception {
@@ -41,12 +41,6 @@ public class LibraryControllerIT {
     public void testUnknownMusicIdRouteCall() throws Exception{
         mockMvc.perform(get("/library/music/1000"))
                 .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    public void testServerError() throws Exception{
-        mockMvc.perform(get("/library/music/0"))
-                .andExpect(status().isInternalServerError());
     }
 
     @Test

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
@@ -1,0 +1,32 @@
+package com.theodo.Albeniz.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = LibraryController.class)
+@AutoConfigureMockMvc
+public class LibraryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testGetLibraryRoute() throws Exception{
+        mockMvc.perform(get("/library/music").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        "[" +
+                                "{'title': 'Thriller', 'author': 'MJ'}," +
+                                "{'title': 'Bohemian Rapsody', 'author': 'Queen'}," +
+                                "{'title': 'Allumer le feu', 'author': 'Johnny'}" +
+                                "]"));
+        }
+}

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
@@ -1,0 +1,78 @@
+
+package com.theodo.Albeniz.controller;
+
+import com.theodo.Albeniz.Service.LibraryService;
+import com.theodo.Albeniz.dto.Tune;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = LibraryController.class)
+public class LibraryControllerTest {
+
+    @MockBean
+    private LibraryService libraryService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    List<Tune> completeLibrary = Arrays.asList(
+            new Tune(1, "Thriller", "MJ"),
+            new Tune(2, "Bohemian Rhapsody", "Queen"),
+            new Tune(3, "Allumer le feu", "Johnny")
+    );
+
+    List<Tune> searchedLibrary = Arrays.asList(
+            new Tune(1, "Thriller", "MJ"),
+            new Tune(3, "Allumer le feu", "Johnny")
+    );
+
+    Tune bohemianTune = new Tune(2, "Bohemian Rhapsody", "Queen");
+
+    @Test
+    public void testGetLibraryRouteWithoutSearchQueryTerm() throws Exception{
+        BDDMockito.given(this.libraryService.getMusic(null)).willReturn(completeLibrary);
+        mockMvc.perform(get("/library/music").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        "[" +
+                                "{'id': 1, 'title': 'Thriller', 'author': 'MJ'}," +
+                                "{'id': 2, 'title': 'Bohemian Rhapsody', 'author': 'Queen'}," +
+                                "{'id': 3, 'title': 'Allumer le feu', 'author': 'Johnny'}" +
+                                "]"));
+    }
+
+    @Test
+    public void testGetLibraryRouteWithSearchQueryTerm() throws Exception{
+        BDDMockito.given(this.libraryService.getMusic("ll")).willReturn(searchedLibrary);
+        mockMvc.perform(get("/library/music?query=ll").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        "[" +
+                                "{'id': 1, 'title': 'Thriller', 'author': 'MJ'}," +
+                                "{'id': 3, 'title': 'Allumer le feu', 'author': 'Johnny'}" +
+                                "]"));
+    }
+
+    @Test
+    public void testGetLibraryRouteWithSear() throws Exception{
+        BDDMockito.given(this.libraryService.getOne(2)).willReturn(bohemianTune);
+        mockMvc.perform(get("/library/music/2").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        "{'id': 2, 'title': 'Bohemian Rhapsody', 'author': 'Queen'}"
+                ));
+    }
+    }

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
@@ -31,7 +31,7 @@ public class LibraryControllerTest {
         }
 
     @Test
-    public void testSpecificMusicById() throws Exception{
+    public void testGetSpecificMusicById() throws Exception{
         mockMvc.perform(get("/library/music/1").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json("{'id': 1, 'title': 'Thriller', 'author': 'MJ'}"));
@@ -39,7 +39,23 @@ public class LibraryControllerTest {
 
     @Test
     public void testUnknownMusicIdRouteCall() throws Exception{
-        mockMvc.perform(get("/library/music/badID"))
-                .andExpect(status().is4xxClientError());
+        mockMvc.perform(get("/library/music/1000"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testServerError() throws Exception{
+        mockMvc.perform(get("/library/music/0"))
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    public void testGetMusicBySearch() throws Exception{
+        mockMvc.perform(get("/library/music?query=ll").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[" +
+                        "{'id': 1, 'title': 'Thriller', 'author': 'MJ'}," +
+                        "{'id': 3, 'title': 'Allumer le feu', 'author': 'Johnny'}" +
+                        "]"));
     }
 }

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
@@ -24,9 +24,22 @@ public class LibraryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         "[" +
-                                "{'title': 'Thriller', 'author': 'MJ'}," +
-                                "{'title': 'Bohemian Rapsody', 'author': 'Queen'}," +
-                                "{'title': 'Allumer le feu', 'author': 'Johnny'}" +
+                                "{'id': 1, 'title': 'Thriller', 'author': 'MJ'}," +
+                                "{'id': 2, 'title': 'Bohemian Rapsody', 'author': 'Queen'}," +
+                                "{'id': 3, 'title': 'Allumer le feu', 'author': 'Johnny'}" +
                                 "]"));
         }
+
+    @Test
+    public void testSpecificMusicById() throws Exception{
+        mockMvc.perform(get("/library/music/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{'id': 1, 'title': 'Thriller', 'author': 'MJ'}"));
+    }
+
+    @Test
+    public void testUnknownMusicIdRouteCall() throws Exception{
+        mockMvc.perform(get("/library/music/badID"))
+                .andExpect(status().is4xxClientError());
+    }
 }

--- a/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
+++ b/src/test/java/com/theodo/Albeniz/controller/LibraryControllerTest.java
@@ -67,7 +67,7 @@ public class LibraryControllerTest {
     }
 
     @Test
-    public void testGetLibraryRouteWithSear() throws Exception{
+    public void testGetSpecificTune() throws Exception{
         BDDMockito.given(this.libraryService.getOne(2)).willReturn(bohemianTune);
         mockMvc.perform(get("/library/music/2").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/theodo/Albeniz/services/LibraryServiceTest.java
+++ b/src/test/java/com/theodo/Albeniz/services/LibraryServiceTest.java
@@ -2,14 +2,13 @@
 
 package com.theodo.Albeniz.services;
 
-import com.theodo.Albeniz.Service.LibraryService;
+import com.theodo.Albeniz.Service.InMemoryLibraryServiceMock;
 import com.theodo.Albeniz.dto.Tune;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 public class LibraryServiceTest {
 
@@ -28,13 +27,13 @@ public class LibraryServiceTest {
 
     @Test
     public void testGetAll() throws Exception{
-        LibraryService libraryService = new LibraryService();
-        Assertions.assertEquals(completeLibrary, libraryService.getMusic(null));
+        InMemoryLibraryServiceMock inMemoryLibraryServiceMock = new InMemoryLibraryServiceMock();
+        Assertions.assertEquals(completeLibrary, inMemoryLibraryServiceMock.getMusic(null));
     }
 
     @Test
     public void testGetBySearch() throws Exception{
-        LibraryService libraryService = new LibraryService();
-        Assertions.assertEquals(searchedLibrary, libraryService.getMusic("ll"));
+        InMemoryLibraryServiceMock inMemoryLibraryServiceMock = new InMemoryLibraryServiceMock();
+        Assertions.assertEquals(searchedLibrary, inMemoryLibraryServiceMock.getMusic("ll"));
     }
 }

--- a/src/test/java/com/theodo/Albeniz/services/LibraryServiceTest.java
+++ b/src/test/java/com/theodo/Albeniz/services/LibraryServiceTest.java
@@ -1,0 +1,40 @@
+
+
+package com.theodo.Albeniz.services;
+
+import com.theodo.Albeniz.Service.LibraryService;
+import com.theodo.Albeniz.dto.Tune;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class LibraryServiceTest {
+
+    List<Tune> completeLibrary = Arrays.asList(
+            new Tune(1, "Thriller", "MJ"),
+            new Tune(2, "Bohemian Rhapsody", "Queen"),
+            new Tune(3, "Allumer le feu", "Johnny")
+    );
+
+    List<Tune> searchedLibrary = Arrays.asList(
+            new Tune(1, "Thriller", "MJ"),
+            new Tune(3, "Allumer le feu", "Johnny")
+    );
+
+
+
+    @Test
+    public void testGetAll() throws Exception{
+        LibraryService libraryService = new LibraryService();
+        Assertions.assertEquals(completeLibrary, libraryService.getMusic(null));
+    }
+
+    @Test
+    public void testGetBySearch() throws Exception{
+        LibraryService libraryService = new LibraryService();
+        Assertions.assertEquals(searchedLibrary, libraryService.getMusic("ll"));
+    }
+}


### PR DESCRIPTION
Add two profiles to specify which data Library Service is used: memory (for testing) or database (for "production")